### PR TITLE
Update ConnectionManager.java

### DIFF
--- a/src/main/java/space/ponyo/dc1/server/server/ConnectionManager.java
+++ b/src/main/java/space/ponyo/dc1/server/server/ConnectionManager.java
@@ -29,7 +29,7 @@ public class ConnectionManager {
         if (localPort == 8800) {
             executorService.execute(() -> mPhoneConnectionMap.get(ip + ":" + remotePort).processMessage(msg));
         } else {
-            executorService.execute(() -> mDeviceConnectionMap.get(ip).processMessage(msg));
+            executorService.execute(() -> mDeviceConnectionMap.get(ip + ":" + remotePort).processMessage(msg));
         }
     }
 
@@ -52,7 +52,7 @@ public class ConnectionManager {
             DeviceConnection connection = mDeviceConnectionMap.get(ip);
             if (connection == null) {
                 connection = new DeviceConnection();
-                mDeviceConnectionMap.put(ip, connection);
+                mDeviceConnectionMap.put(ip + ":" + remotePort, connection);
             }
             connection.setChannel(channel);
             return connection;
@@ -72,10 +72,10 @@ public class ConnectionManager {
             }
             mPhoneConnectionMap.remove(ip + ":" + remotePort);
         } else {
-            if (mDeviceConnectionMap.get(ip).isActive()) {
+            if (mDeviceConnectionMap.get(ip + ":" + remotePort).isActive()) {
                 return;
             }
-            mDeviceConnectionMap.remove(ip);
+            mDeviceConnectionMap.remove(ip + ":" + remotePort);
         }
     }
 


### PR DESCRIPTION
mDeviceConnectionMap的key由ip改为ip+port，以解决如下问题：
server部署在本地局域网内时，多个DC1连接，IP为内网ip，是不同的，没有问题。
但如果将server部署到外网云服务器，由于同一路由器下的多个DC1，外网ip一致，在此处如用ip作为key，多个dc1在mDeviceConnectionMap将是同一个key，会引发一直重复发送激活报文的问题。